### PR TITLE
Fix Copilot review comments from PR #1

### DIFF
--- a/examples/Wolfgang.Extensions.String.Examples/Program.cs
+++ b/examples/Wolfgang.Extensions.String.Examples/Program.cs
@@ -20,7 +20,7 @@ internal abstract class Program
             Console.WriteLine($"\t{"Name".PadCenter(10)}|{"Date".PadCenter(12)}");
             Console.WriteLine("\t----------+------------");
             Console.WriteLine($"\t{"Steve",-10}|{DateTime.Today.ToString("MM/dd/yyyy").PadCenter(12)}");
-            Console.WriteLine($"\t{"Jane",-10}|{DateTime.Today.ToString("1/2/2012").PadCenter(12)}");
+            Console.WriteLine($"\t{"Jane",-10}|{new DateTime(2012, 1, 2).ToString("M/d/yyyy").PadCenter(12)}");
             Console.WriteLine();
         }
 

--- a/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
+++ b/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Wolfgang.Extensions.String\Wolfgang.Extensions.String.csproj" />
-    <ProjectReference Include="..\src\Wolfgang.Extensions.String\Wolfgang.Extensions.String.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Extensions.String/StringExtensions.cs
+++ b/src/Wolfgang.Extensions.String/StringExtensions.cs
@@ -39,7 +39,7 @@ public static class StringExtensions
 
 
     /// <summary>
-    /// Returns a new string of a specified length in which the current string is centered with spaces padding either size
+    /// Returns a new string of a specified length in which the current string is centered with spaces padding either side
     /// </summary>
     /// <param name="s"></param>
     /// <param name="totalWidth"></param>
@@ -49,7 +49,7 @@ public static class StringExtensions
 
 
     /// <summary>
-    /// Returns a new string of a specified length in which the current string is centered with specified character padding either size
+    /// Returns a new string of a specified length in which the current string is centered with specified character padding either side
     /// </summary>
     /// <param name="s"></param>
     /// <param name="totalWidth"></param>

--- a/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
+++ b/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
@@ -14,7 +14,7 @@
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for strings</Description>
 		<Copyright>Copyright 2026 Chris Wolfgang </Copyright>
-		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Wolfgang.Extensions.IComparable</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/String-Extensions</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
Addresses all 5 Copilot review comments from PR #1:

- **PackageProjectUrl** — was pointing to `Wolfgang.Extensions.IComparable` repo, corrected to `String-Extensions`
- **Duplicate ProjectReference** — removed duplicate reference in examples `.csproj` (kept the correct `..\..\src\` path)
- **Typo "size" -> "side"** — fixed in both `PadCenter` XML doc comments
- **Invalid DateTime format** — `"1/2/2012"` was used as a format string instead of an actual date; replaced with `new DateTime(2012, 1, 2).ToString("M/d/yyyy")`

## Test plan
- [x] Build passes (`dotnet build --configuration Release`)
- [x] All 82 tests pass on net8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)