### PR TITLE
Fix pull_request_target trigger not firing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,11 +7,13 @@ name: PR Checks v2 (Gated)
 
 permissions:
   contents: read
-  
+
 on:
-  pull_request_target:  # Runs from the main branch, not from PR branch 
-    branches: 
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
       - main
+
 jobs:
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate


### PR DESCRIPTION
## Summary
- Remove trailing whitespace from `pull_request_target` trigger lines in `pr.yaml`
- Add explicit `types: [opened, synchronize, reopened]`
- Add blank line before `jobs:` for clarity

PR #19 checks were not running because the `pull_request_target` event never fired. This fix cleans up the YAML trigger section to resolve the issue.

## Test plan
- [ ] Merge this PR into main
- [ ] Verify PR #19 checks start running after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)