### PR TITLE
Move analyzer PackageReferences to individual csproj files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,41 +19,10 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- AsyncFixer - Async/await best practices -->
-    <PackageReference Include="AsyncFixer" Version="2.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+  <!--
+    Analyzer PackageReferences are intentionally declared in each csproj rather
+    than here. This makes each project's dependencies explicit, lets per-project
+    versions diverge if needed, and keeps Dependabot bumps from cascading
+    across unrelated projects.
+  -->
 </Project>

--- a/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
+++ b/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
@@ -11,4 +11,43 @@
     <ProjectReference Include="..\..\src\Wolfgang.Extensions.String\Wolfgang.Extensions.String.csproj" />
   </ItemGroup>
 
+  <!-- Analyzers -->
+  <ItemGroup>
+    <!-- Roslynator - Code quality and refactoring -->
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- AsyncFixer - Async/await best practices -->
+    <PackageReference Include="AsyncFixer" Version="2.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Microsoft Threading Analyzers - Thread safety -->
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Meziantou - Comprehensive code quality -->
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- SonarAnalyzer - Industry-standard analysis -->
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
+++ b/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
@@ -30,6 +30,44 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<!-- Roslynator - Code quality and refactoring -->
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- AsyncFixer - Async/await best practices -->
+		<PackageReference Include="AsyncFixer" Version="2.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Microsoft Threading Analyzers - Thread safety -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Meziantou - Comprehensive code quality -->
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- SonarAnalyzer - Industry-standard analysis -->
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
 	  <Content Include="icon.ico" />
 	</ItemGroup>
 

--- a/tests/Wolfgang.Extensions.String.Tests.Unit/Wolfgang.Extensions.String.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.String.Tests.Unit/Wolfgang.Extensions.String.Tests.Unit.csproj
@@ -23,6 +23,45 @@
 		<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
 	</ItemGroup>
 
+	<!-- Analyzers -->
+	<ItemGroup>
+		<!-- Roslynator - Code quality and refactoring -->
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- AsyncFixer - Async/await best practices -->
+		<PackageReference Include="AsyncFixer" Version="2.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Microsoft Threading Analyzers - Thread safety -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- Meziantou - Comprehensive code quality -->
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+
+		<!-- SonarAnalyzer - Industry-standard analysis -->
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
 	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
 	<ItemGroup Condition="&#xD;&#xA;			   '$(TargetFramework)' == 'net462' or&#xD;&#xA;			   '$(TargetFramework)' == 'net472' or&#xD;&#xA;			   '$(TargetFramework)' == 'net48' or&#xD;&#xA;			   '$(TargetFramework)' == 'net481'&#xD;&#xA;			   ">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />


### PR DESCRIPTION
## Summary
Move the 6 analyzer PackageReferences out of `Directory.Build.props` and into each individual `.csproj` (src, tests, examples). Shared analyzer-related MSBuild properties (`EnableNETAnalyzers`, `EnforceCodeStyleInBuild`, `TreatWarningsAsErrors`, `BannedSymbols.txt` AdditionalFile) remain in `Directory.Build.props`.

Packages moved:
- Roslynator.Analyzers
- AsyncFixer
- Microsoft.VisualStudio.Threading.Analyzers
- Microsoft.CodeAnalysis.BannedApiAnalyzers
- Meziantou.Analyzer
- SonarAnalyzer.CSharp

## Why
- Each project's dependencies are explicit and visible
- Per-project versions can diverge if needed
- Dependabot version bumps no longer cascade across unrelated projects

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test` (net8.0) — 95/95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)