### PR TITLE
Bump Meziantou.Analyzer to 3.0.50 and SonarAnalyzer.CSharp to 10.24.0.138807

### DIFF
--- a/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
+++ b/examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj
@@ -38,13 +38,13 @@
     </PackageReference>
 
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.50">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
+++ b/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
@@ -55,13 +55,13 @@
 		</PackageReference>
 
 		<!-- Meziantou - Comprehensive code quality -->
-		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.50">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 
 		<!-- SonarAnalyzer - Industry-standard analysis -->
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/Wolfgang.Extensions.String.Tests.Unit/Wolfgang.Extensions.String.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.String.Tests.Unit/Wolfgang.Extensions.String.Tests.Unit.csproj
@@ -50,13 +50,13 @@
 		</PackageReference>
 
 		<!-- Meziantou - Comprehensive code quality -->
-		<PackageReference Include="Meziantou.Analyzer" Version="3.0.27">
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.50">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 
 		<!-- SonarAnalyzer - Industry-standard analysis -->
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.21.0.135717">
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary
Replaces stale Dependabot PRs #27 and #28 which still targeted `Directory.Build.props` (the analyzer references moved to individual csproj files in PR #29).

- Meziantou.Analyzer: 3.0.27 → 3.0.50
- SonarAnalyzer.CSharp: 10.21.0.135717 → 10.24.0.138807

Updated in all three csproj files (src, tests, examples).

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test` (net8.0) — 95/95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)