### PR TITLE
docfx: pin metadata TargetFramework to net10.0

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -10,7 +10,10 @@
           "src": "../"
         }
       ],
-      "dest": "api"
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "net10.0"
+      }
     }
   ],
   "build": {


### PR DESCRIPTION
## Summary
Adds a `properties.TargetFramework` to `docfx_project/docfx.json` so docfx compiles against `net10.0` rather than auto-picking a TFM (which here picks one without BCL reference assemblies).

## Why
The v0.1.0 release run's `Build & Deploy Documentation` job failed with:

```
error CS0518: Predefined type 'System.String' is not defined or imported
error CS1110: Cannot define a new extension because the compiler required type
              'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found.
```

The csproj targets `net462;netstandard2.0;net8.0;net10.0` and docfx was likely picking `net462` or `netstandard2.0`, where the BCL assemblies aren't on the resolution path.

ICollection-Extensions's `docfx.json` already has `"properties": { "TargetFramework": "net8.0" }` for the same reason — this PR mirrors that fix using `net10.0` (since this csproj also targets it).

## Test plan
- [ ] After merge, re-cut the v0.1.0 release and confirm the docs job succeeds