### PR TITLE
Sync .gitignore from canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@
 # Claude Code
 .claude/
 
-# ReSharper / JetBrains Rider inspection output
-inspections.xml
-
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
@@ -425,3 +422,12 @@ FodyWeavers.xsd
 # Test results and coverage
 TestResults/
 CoverageReport/
+
+# Release workflow temporary directories
+package-smoke-test/
+nuget-packages/
+
+# DocFX generated files
+docfx_project/_site/
+docfx_project/obj/
+


### PR DESCRIPTION
## Summary
Syncs `.gitignore` and (if applicable) `.gitleaks.toml` to canonical (`repo-template/main`).

These are protected configuration files. The PR workflow will fail by design on the protected-files guard. Requires admin merge after verifying the diff matches canonical byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)