### PR TITLE
Sync .github/dependabot.yml from canonical

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/" # Root - for solution-level dependencies
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "dotnet"
-
-  - package-ecosystem: "nuget"
-    directory: "/src"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "dotnet"
-
-  - package-ecosystem: "nuget"
-    directory: "/tests"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "dotnet"
-
-  - package-ecosystem: "nuget"
-    directory: "/benchmarks"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "dotnet"
-
-  - package-ecosystem: "nuget"
-    directory: "/examples"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "dotnet"
+    groups:
+      dotnet-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Syncs `.github/dependabot.yml` to canonical (`repo-template/main`).

## What changes
The old config has 4 separate `nuget` ecosystem entries (one each for `/`, `/src`, `/tests`, `/benchmarks`) with `open-pull-requests-limit: 5` and no grouping. Canonical replaces this with a single ecosystem entry on `/` with grouped dependencies (`dotnet-dependencies: patterns: ["*"]`) and `open-pull-requests-limit: 10`.

## Why
- One grouped PR per Dependabot run instead of up to 4 unrelated PRs
- Higher limit accommodates more concurrent updates without dropping any
- Single ecosystem block is the new canonical convention

## Test plan
- [ ] Maintainer admin merge (`.github/dependabot.yml` is protected)
- [ ] Next Dependabot run produces a single grouped PR
