### PR TITLE
pr.yaml: GPG-verified focal-security install via signed-by=

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,7 +327,7 @@ jobs:
       # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          echo "deb https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          echo "deb [trusted=yes] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
           sudo apt-get update -q
           sudo apt-get install --yes libssl1.1
           sudo rm /etc/apt/sources.list.d/focal-security.list

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,7 +327,13 @@ jobs:
       # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          echo "deb [trusted=yes] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          # signed-by= points apt at the Canonical archive keyring that ships on all
+          # GitHub-hosted Ubuntu runners. It contains the same signing key Canonical
+          # uses across releases (focal, jammy, noble), so it can verify focal-security
+          # packages from a non-focal runner without disabling signature checking.
+          # Earlier iteration used [trusted=yes] (skipping verification) as a quick
+          # unblock; this restores end-to-end signature verification.
+          echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
           sudo apt-get update -q
           sudo apt-get install --yes libssl1.1
           sudo rm /etc/apt/sources.list.d/focal-security.list


### PR DESCRIPTION
## Summary
Adds the `focal-security` apt source with `[signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg]`, allowing apt to install `libssl1.1` for the .NET 5.0 test stage on newer Ubuntu runners while keeping GPG signature verification enabled.

## Why
This step was previously failing on newer GitHub-hosted Ubuntu runners with `E: Package 'libssl1.1' has no installation candidate`. apt was silently `Ign`-ing the source because no `signed-by=` directive pointed it at a keyring containing the focal signing key. The Canonical archive keyring at `/usr/share/keyrings/ubuntu-archive-keyring.gpg` is present on every GitHub-hosted Ubuntu runner and contains the same signing key Canonical uses across releases (focal, jammy, noble), so it can verify focal-security packages from a non-focal runner without disabling signature checking.

An earlier iteration of this rollout used `[trusted=yes]` (skipping verification) as a quick unblock; this PR brings in the keyring-based replacement that restores end-to-end signature verification.

## Validation
Tested end-to-end against the actual `ubuntu-latest` (noble 24.04) runner image — see the run linked in [repo-template#336](https://github.com/Chris-Wolfgang/repo-template/pull/336). This PR is part of the rollout to the 18 affected repos.

## Note for reviewers
This PR edits `.github/workflows/pr.yaml`, which the v3 PR-Checks workflow treats as a protected configuration file. The "Detect protected configuration file changes" step will fail CI by design — that is the explicit guard against PRs disabling analyzers/scans by modifying workflows. The change here is the canonical `pr.yaml` sync from `repo-template`, so maintainer-bypass merge (or local validation against canonical) is appropriate.
