### PR TITLE
Add github-actions ecosystem to Dependabot (sync workflow action pins)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,16 @@ updates:
       dotnet-dependencies:
         patterns:
           - "*"
+
+  # Keep third-party GitHub Actions pinned in workflows up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes the corresponding "CI/CD: Add the github-actions ecosystem to Dependabot" maintenance issue in this repo.

## Summary

Adds the `github-actions` ecosystem block to `.github/dependabot.yml` so Dependabot keeps third-party action pins in workflow files up to date (currently it only manages NuGet packages).

## Change

Appends the canonical block to `dependabot.yml`:

```yaml
  # Keep third-party GitHub Actions pinned in workflows up to date.
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 10
    labels:
      - "dependencies"
    groups:
      github-actions:
        patterns:
          - "*"
```

Block matches the canonical version live in `In-memory-Logger`. Weekly schedule + grouped PRs to keep noise low; `dependencies` label so PRs are filterable.