### PR TITLE
Convert README headers to canonical emoji style (D1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collection of extension methods for strings targeting .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, and .NET 10.0.
 
-## Installation
+## 📦 Installation
 
 ```bash
 dotnet add package Wolfgang.Extensions.String
@@ -116,12 +116,12 @@ Console.WriteLine(input.ToSnakeCase());   // "user_login_count"
 Console.WriteLine(input.ToTitleCase());   // "User Login Count"
 ```
 
-## Documentation
+## 📚 Documentation
 
 - [API Reference](https://chris-wolfgang.github.io/String-Extensions/api/)
 - [Getting Started](https://chris-wolfgang.github.io/String-Extensions/docs/getting-started.html)
 - [Introduction](https://chris-wolfgang.github.io/String-Extensions/docs/introduction.html)
 
-## License
+## 📄 License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Closes the corresponding "docs: Convert README to canonical emoji section style (D1)" maintenance issue.

## Summary

Updates `README.md` section headers to use the canonical emoji style adopted fleet-wide (repo-template, IAsync-Extensions, DateTime-Extensions, ETL-FixedWidth/Abstractions/Test-Kit, D20-Dice, Hawsey, Log-Compressor, and others).

## Header mapping

| Plain | Canonical |
|---|---|
| `## Installation` | `## 📦 Installation` |
| `## Quick Start` | `## 🚀 Quick Start` |
| `## Features` | `## ✨ Features` |
| `## Target Frameworks` | `## 🎯 Target Frameworks` |
| `## Documentation` | `## 📚 Documentation` |
| `## License` | `## 📄 License` |
| `## Code Quality & Static Analysis` | `## 🔍 Code Quality & Static Analysis` |
| `## Contributing` | `## 🤝 Contributing` |

Header-rename only — no prose or code-sample changes. GitHub auto-slugs section anchors so existing `#installation`-style fragment links still resolve.