### PR TITLE
Stand up BenchmarkDotNet baseline project + benchmarks/.editorconfig (#63, #85)

### DIFF
--- a/String Extensions.slnx
+++ b/String Extensions.slnx
@@ -24,7 +24,9 @@
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Extensions.String.Benchmarks/Wolfgang.Extensions.String.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/">
     <Project Path="examples/Wolfgang.Extensions.String.Examples/Wolfgang.Extensions.String.DotNet8.Examples.csproj" />
   </Folder>

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,30 @@
+# Benchmark-project EditorConfig override.
+#
+# Benchmarks intentionally do things that production code shouldn't:
+#   - public methods returning values that are immediately discarded
+#     (the whole point — BenchmarkDotNet's [Benchmark] attribute requires
+#     public methods so it can JIT them as separate callable wrappers)
+#   - allocations measured as expected output, not regressions
+#   - constants chosen to bias toward slow / fast paths rather than
+#     reflecting realistic input
+#
+# Rules from the root .editorconfig and Directory.Build.props
+# (TreatWarningsAsErrors=true in Release) still apply; this file just
+# relaxes the analyzer rules that the BDN attribute model would otherwise
+# trip if a benchmark method stops touching instance state.
+root = false
+
+[*.cs]
+
+# Roslynator / .NET: "Mark members as static" — BenchmarkDotNet's [Benchmark]
+# methods are instance-level by design.
+dotnet_diagnostic.RCS1213.severity = none
+dotnet_diagnostic.CA1822.severity = none
+
+# Meziantou: "Use a return type with the value type Span<T>" — benchmark
+# return values are sinks, not actual outputs callers depend on.
+dotnet_diagnostic.MA0089.severity = none
+
+# Sonar: "Methods should not have identical implementations" — common
+# in fast-path / slow-path comparison benchmarks.
+dotnet_diagnostic.S4144.severity = none

--- a/benchmarks/.gitkeep
+++ b/benchmarks/.gitkeep
@@ -1,1 +1,0 @@
-# Benchmarks

--- a/benchmarks/Wolfgang.Extensions.String.Benchmarks/CasingBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.String.Benchmarks/CasingBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.String;
+
+namespace Wolfgang.Extensions.String.Benchmarks;
+
+/// <summary>
+/// Measures the casing conversions (<see cref="StringExtensions.ToCamelCase"/>,
+/// <see cref="StringExtensions.ToPascalCase"/>, <see cref="StringExtensions.ToKebabCase"/>,
+/// <see cref="StringExtensions.ToSnakeCase"/>, <see cref="StringExtensions.ToTitleCase"/>)
+/// over a representative multi-word input. <see cref="StringExtensions.ToTitleCase"/>
+/// delegates to <see cref="System.Globalization.TextInfo.ToTitleCase"/> and serves as the
+/// BCL-backed reference point.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class CasingBenchmarks
+{
+    private string _input = null!;
+
+    [GlobalSetup]
+    public void Setup() => _input = " A sample string for processing! ";
+
+    [Benchmark(Baseline = true)]
+    public string ToTitleCase() => _input.ToTitleCase();
+
+    [Benchmark]
+    public string ToCamelCase() => _input.ToCamelCase();
+
+    [Benchmark]
+    public string ToPascalCase() => _input.ToPascalCase();
+
+    [Benchmark]
+    public string ToKebabCase() => _input.ToKebabCase();
+
+    [Benchmark]
+    public string ToSnakeCase() => _input.ToSnakeCase();
+}

--- a/benchmarks/Wolfgang.Extensions.String.Benchmarks/LeftRightBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.String.Benchmarks/LeftRightBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.String;
+
+namespace Wolfgang.Extensions.String.Benchmarks;
+
+/// <summary>
+/// Compares <see cref="StringExtensions.Left(string, int)"/> and
+/// <see cref="StringExtensions.Right(string, int)"/> against the raw
+/// <see cref="string.Substring(int, int)"/> calls they encapsulate. The
+/// extensions add length-clamping and null-tolerance the BCL substring lacks,
+/// so this measures the cost of that safety.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class LeftRightBenchmarks
+{
+    private string _input = null!;
+
+    private const int Length = 8;
+
+    [GlobalSetup]
+    public void Setup() => _input = "The quick brown fox jumps over the lazy dog";
+
+    [Benchmark(Baseline = true)]
+    public string Substring_Left() => _input.Substring(0, Length);
+
+    [Benchmark]
+    public string Left() => _input.Left(Length)!;
+
+    [Benchmark]
+    public string Substring_Right() => _input.Substring(_input.Length - Length, Length);
+
+    [Benchmark]
+    public string Right() => _input.Right(Length)!;
+}

--- a/benchmarks/Wolfgang.Extensions.String.Benchmarks/PadCenterBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.String.Benchmarks/PadCenterBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.String;
+
+namespace Wolfgang.Extensions.String.Benchmarks;
+
+/// <summary>
+/// Compares <see cref="StringExtensions.PadCenter(string, int)"/> (and its
+/// padding-char overload) against the canonical hand-rolled
+/// <see cref="string.PadLeft(int)"/> + <see cref="string.PadRight(int)"/> idiom
+/// callers reach for when no center-pad helper exists.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class PadCenterBenchmarks
+{
+    private string _input = null!;
+
+    private const int TotalWidth = 80;
+
+    [GlobalSetup]
+    public void Setup() => _input = "centered";
+
+    [Benchmark(Baseline = true)]
+    public string Manual_PadLeftPadRight()
+    {
+        var leftPadding = (TotalWidth - _input.Length) / 2;
+        return _input.PadLeft(_input.Length + leftPadding).PadRight(TotalWidth);
+    }
+
+    [Benchmark]
+    public string PadCenter() => _input.PadCenter(TotalWidth);
+
+    [Benchmark]
+    public string PadCenter_WithChar() => _input.PadCenter(TotalWidth, '*');
+}

--- a/benchmarks/Wolfgang.Extensions.String.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.String.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.String.Benchmarks/Wolfgang.Extensions.String.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.String.Benchmarks/Wolfgang.Extensions.String.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Benchmark targets net8.0 only; BenchmarkDotNet runs against a single TFM. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.String\Wolfgang.Extensions.String.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Stand up BenchmarkDotNet baseline project (#63, P1) + curated benchmarks/.editorconfig (#85)

### #63 — BenchmarkDotNet baseline project
- New `benchmarks/Wolfgang.Extensions.String.Benchmarks/` (net8.0, `OutputType=Exe`, `BenchmarkSwitcher` entry point), referencing the src project.
- Three benchmark classes covering all 9 public methods:
  - **CasingBenchmarks** — `ToCamelCase` / `ToPascalCase` / `ToKebabCase` / `ToSnakeCase`, baselined against the BCL-backed `ToTitleCase`.
  - **PadCenterBenchmarks** — both `PadCenter` overloads vs the manual `PadLeft`+`PadRight` idiom.
  - **LeftRightBenchmarks** — `Left` / `Right` vs raw `Substring`.
- `[MemoryDiagnoser]` + `[RankColumn]` on each.
- Added to the solution's `/benchmarks/` folder.
- Baseline (ShortRun) executes cleanly — 12 benchmarks.

### #85 — benchmarks held to TreatWarningsAsErrors
- Project **builds clean in Release under the root `TreatWarningsAsErrors`** (0 warnings).
- No `benchmarks/Directory.Build.props` existed, so it already inherits the root props bar (step 3 was a no-op).
- Added curated `benchmarks/.editorconfig` (canonical sync rule set: `RCS1213`, `CA1822`, `MA0089`, `S4144`) — relaxes only genuinely-benchmark-inappropriate rules.

### Note
MemoryDiagnoser flagged `PadCenter` allocating **608 B vs 296 B** for the manual approach (~1.8× slower) — a candidate future optimization, out of scope here.

Closes #63
Closes #85
