### PR TITLE
Standardize README structure + status badges (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Wolfgang.Extensions.String
 
-A collection of extension methods for strings targeting .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, and .NET 10.0.
+A collection of extension methods for `string` — substring helpers (`Left` / `Right`), center-padding (`PadCenter`), and case conversions (`ToCamelCase` / `ToKebabCase` / `ToPascalCase` / `ToSnakeCase` / `ToTitleCase`).
+
+[![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.String.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.String)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.String.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.String)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/String-Extensions/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/String-Extensions/actions/workflows/pr.yaml)
+[![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/String-Extensions/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/String-Extensions/actions/workflows/release.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
+[![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/String-Extensions)
+
+---
 
 ## 📦 Installation
 
@@ -8,101 +18,38 @@ A collection of extension methods for strings targeting .NET Framework 4.6.2, .N
 dotnet add package Wolfgang.Extensions.String
 ```
 
-## Methods
+---
 
-### Left
+## 📄 License
 
-Returns the leftmost characters from a string.
+This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for details.
 
-```csharp
-"A sample string".Left(8);   // "A sample"
-"Hello".Left(10);             // "Hello"
-"Hello".Left(0);              // ""
-```
+---
 
-### Right
+## 📚 Documentation
 
-Returns the rightmost characters from a string.
+- **GitHub Repository:** [https://github.com/Chris-Wolfgang/String-Extensions](https://github.com/Chris-Wolfgang/String-Extensions)
+- **API Documentation:** [https://Chris-Wolfgang.github.io/String-Extensions/](https://Chris-Wolfgang.github.io/String-Extensions/)
+- **CHANGELOG:** [CHANGELOG.md](CHANGELOG.md)
+- **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Formatting Guide:** [docs/README-FORMATTING.md](docs/README-FORMATTING.md)
+- **Release Workflow Setup:** [docs/RELEASE-WORKFLOW-SETUP.md](docs/RELEASE-WORKFLOW-SETUP.md)
+- **Workflow Security:** [docs/WORKFLOW_SECURITY.md](docs/WORKFLOW_SECURITY.md)
 
-```csharp
-"A sample string".Right(6);  // "string"
-"Hello".Right(10);            // "Hello"
-"Hello".Right(0);             // ""
-```
+---
 
-### PadCenter
-
-Centers a string within a specified width, padding both sides with spaces or a specified character.
+## 🚀 Quick Start
 
 ```csharp
-"Hello".PadCenter(11);        // "   Hello   "
-"Hello".PadCenter(11, '-');   // "---Hello---"
-"Hello".PadCenter(3);         // "Hello"
-```
-
-### ToCamelCase
-
-Converts a string to camelCase.
-
-```csharp
-// Input                              → Output
-"A sample string for processing"      → "aSampleStringForProcessing"
-"hello world"                         → "helloWorld"
-```
-
-### ToKebabCase
-
-Converts a string to kebab-case.
-
-```csharp
-// Input                              → Output
-"A sample string for processing"      → "a-sample-string-for-processing"
-"Hello World"                         → "hello-world"
-```
-
-### ToPascalCase
-
-Converts a string to PascalCase.
-
-```csharp
-// Input                              → Output
-"A sample string for processing"      → "ASampleStringForProcessing"
-"hello world"                         → "HelloWorld"
-```
-
-### ToSnakeCase
-
-Converts a string to snake_case.
-
-```csharp
-// Input                              → Output
-"A sample string for processing"      → "a_sample_string_for_processing"
-"Hello World"                         → "hello_world"
-```
-
-### ToTitleCase
-
-Capitalizes the first letter of each word, preserving spaces and punctuation.
-
-```csharp
-// Input                              → Output
-"a sample string for processing"      → "A Sample String For Processing"
-"hello world"                         → "Hello World"
-```
-
-> **Note:** This is a general-purpose implementation that delegates to `TextInfo.ToTitleCase`. Proper names, addresses, and other domain-specific text often require specialized handling (e.g., "McDonald", "van der Berg", "O'Brien") that is not provided here.
-
-## Usage Example
-
-```csharp
+using System;
 using Wolfgang.Extensions.String;
 
-// Substring helpers
+// Substring helpers (null-tolerant, length-clamped)
 var path = "/usr/local/bin/app";
-var first5 = path.Left(5);   // "/usr/"
-var last3 = path.Right(3);   // "app"
+var first5 = path.Left(5);    // "/usr/"
+var last3 = path.Right(3);    // "app"
 
-// Formatted table with centered headers
+// Centered formatting
 Console.WriteLine($"{"Name".PadCenter(10)}|{"Date".PadCenter(12)}");
 Console.WriteLine("----------+------------");
 Console.WriteLine($"{"Steve",-10}|{"04/13/2026".PadCenter(12)}");
@@ -116,12 +63,135 @@ Console.WriteLine(input.ToSnakeCase());   // "user_login_count"
 Console.WriteLine(input.ToTitleCase());   // "User Login Count"
 ```
 
-## 📚 Documentation
+---
 
-- [API Reference](https://chris-wolfgang.github.io/String-Extensions/api/)
-- [Getting Started](https://chris-wolfgang.github.io/String-Extensions/docs/getting-started.html)
-- [Introduction](https://chris-wolfgang.github.io/String-Extensions/docs/introduction.html)
+## ✨ Features
 
-## 📄 License
+The table below is a snapshot of the public API at the time of writing. For the
+authoritative list (kept in sync with source on every release), see the
+[API documentation](https://Chris-Wolfgang.github.io/String-Extensions/api/Wolfgang.Extensions.String.StringExtensions.html).
 
-This project is licensed under the [MIT License](LICENSE).
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Left(this string, int length)` | `string` | Returns the leftmost `length` characters. Returns the whole string when it is shorter than `length`; returns `null` for a `null` input. |
+| `Right(this string, int length)` | `string` | Returns the rightmost `length` characters. Returns the whole string when it is shorter than `length`; returns `null` for a `null` input. |
+| `PadCenter(this string, int totalWidth)` | `string` | Centers the string within `totalWidth`, padding both sides with spaces. When padding is uneven the extra character goes on the right. Returns the original string when it is already at least `totalWidth` long. |
+| `PadCenter(this string, int totalWidth, char paddingChar)` | `string` | As above, padding with `paddingChar` instead of spaces. |
+| `ToCamelCase(this string)` | `string` | Converts to `camelCase`. Separator characters are treated as word boundaries and removed. |
+| `ToKebabCase(this string)` | `string` | Converts to `kebab-case`. Separator characters become dashes. |
+| `ToPascalCase(this string)` | `string` | Converts to `PascalCase`. Separator characters are treated as word boundaries and removed. |
+| `ToSnakeCase(this string)` | `string` | Converts to `snake_case`. Separator characters become underscores. |
+| `ToTitleCase(this string)` | `string` | Converts to `Title Case`, preserving spaces and punctuation. Delegates to `TextInfo.ToTitleCase` using the current culture. |
+
+`Left` / `Right` are length-clamping and null-tolerant. `PadCenter` and the `ToXxxCase` methods throw `ArgumentNullException` for a `null` input; `PadCenter` throws `ArgumentOutOfRangeException` for a negative width. Separator handling uses `char.IsSeparator`, so control characters and punctuation are preserved.
+
+### Examples
+
+```csharp
+// Substring helpers
+"A sample string".Left(8);    // "A sample"
+"Hello".Left(10);             // "Hello"   (shorter than requested → unchanged)
+"Hello".Left(0);              // ""
+
+"A sample string".Right(6);   // "string"
+"Hello".Right(10);            // "Hello"
+"Hello".Right(0);             // ""
+
+// Center padding
+"Hello".PadCenter(11);        // "   Hello   "
+"Hello".PadCenter(11, '-');   // "---Hello---"
+"Hello".PadCenter(3);         // "Hello"   (already wide enough → unchanged)
+
+// Case conversions
+"A sample string for processing".ToCamelCase();   // "aSampleStringForProcessing"
+"A sample string for processing".ToKebabCase();   // "a-sample-string-for-processing"
+"A sample string for processing".ToPascalCase();  // "ASampleStringForProcessing"
+"A sample string for processing".ToSnakeCase();   // "a_sample_string_for_processing"
+"a sample string for processing".ToTitleCase();   // "A Sample String For Processing"
+```
+
+> **Note:** `ToTitleCase` is a general-purpose implementation that delegates to `TextInfo.ToTitleCase`. Proper names, addresses, and other domain-specific text often require specialized handling (e.g., "McDonald", "van der Berg", "O'Brien") that is not provided here.
+
+---
+
+## 🎯 Target Frameworks
+
+| Framework | Versions |
+|-----------|----------|
+| .NET Framework | .NET Framework 4.6.2 |
+| .NET Standard | .NET Standard 2.0 |
+| .NET | .NET 8.0, .NET 10.0 |
+
+---
+
+## 🔍 Code Quality & Static Analysis
+
+This project enforces **strict code quality standards** through **8 analyzer rule sets** (7 explicit `PackageReference`s plus the .NET SDK's built-in `Microsoft.CodeAnalysis.NetAnalyzers`), a `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` Release gate, and a banned-API ruleset:
+
+### Analyzers in Use
+
+1. **Microsoft.CodeAnalysis.NetAnalyzers** — Built-in .NET analyzers for correctness and performance
+2. **Roslynator.Analyzers** — Advanced refactoring and code quality rules
+3. **AsyncFixer** — Async/await best practices and anti-pattern detection
+4. **Microsoft.VisualStudio.Threading.Analyzers** — Thread safety and async patterns
+5. **Microsoft.CodeAnalysis.BannedApiAnalyzers** — Prevents usage of banned synchronous APIs (see `BannedSymbols.txt`)
+6. **Meziantou.Analyzer** — Comprehensive code quality rules
+7. **SonarAnalyzer.CSharp** — Industry-standard code analysis
+8. **Microsoft.CodeAnalysis.PublicApiAnalyzers** — Tracks the public API surface via `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt`; surfaces additions/removals at compile time as a breaking-change review gate
+
+---
+
+## 🛠️ Building from Source
+
+### Prerequisites
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download) — required for the modern build / test / pack flow used by CI
+- Optional: [PowerShell Core](https://github.com/PowerShell/PowerShell) for formatting scripts
+
+### Build Steps
+
+```bash
+# Clone the repository
+git clone https://github.com/Chris-Wolfgang/String-Extensions.git
+cd String-Extensions
+
+# Restore dependencies
+dotnet restore
+
+# Build the solution
+dotnet build --configuration Release
+
+# Run tests
+dotnet test --configuration Release
+
+# Run the benchmarks (optional)
+dotnet run -c Release --project benchmarks/Wolfgang.Extensions.String.Benchmarks -- --filter '*'
+
+# Run code formatting (PowerShell Core)
+pwsh ./scripts/format.ps1
+```
+
+### Code Formatting
+
+This project uses `.editorconfig` and `dotnet format`:
+
+```bash
+# Format code
+dotnet format
+
+# Verify formatting (as CI does)
+dotnet format --verify-no-changes
+```
+
+See [docs/README-FORMATTING.md](docs/README-FORMATTING.md) for detailed formatting guidelines.
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
+- Code quality standards
+- Build and test instructions
+- Pull request guidelines
+- Analyzer configuration details


### PR DESCRIPTION
Brings the README to the canonical structure with the standard badge block (NuGet / downloads / PR build / Release / License / .NET / GitHub) and section layout (Installation → License → Documentation → Quick Start → Features → Target Frameworks → Code Quality → Building from Source → Contributing).

- **#68** (structure + badges) — done.
- **#71 / #88** (accuracy) — partially advanced: documentation links now point only at files/pages that exist; method table + examples verified against the documented transformations. The live `/api/` deploy concern in #88 is a gh-pages deploy-gap matter, tracked separately.

Method examples verified against the casing transformations encoded in the unit tests.

Closes #68