### PR TITLE
Wire docfx version-picker via _appFooter injection (#75)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -51,6 +51,7 @@
       "_appLogoPath": "logo.svg",
       "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
+      "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "pdf": true
     }
   }


### PR DESCRIPTION
The version-selector asset (`docfx_project/public/version-picker.js`) shipped but was never loaded — `docfx.json` had no `_appFooter` to inject it, so the picker never appeared.

Adds the canonical footer loader (matches ICollection-/DateTime-/IComparable-/IEquatable-Extensions) that derives the gh-pages project base path and async-loads `public/version-picker.js` on every page.

**Verified locally:** `docfx metadata` + `docfx build` succeed; the loader is injected into all 7 generated HTML pages. The committed `versions.json` is an empty stub by design — `docfx.yaml` regenerates it from `v*` tags at deploy.

Closes #75