### PR TITLE
Populate CHANGELOG (v0.1.0 history + v0.1.1 round) (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+Canonical maintenance round + binding-stability fix. No public API or runtime
+behavior change vs v0.1.0.
 
 ### Changed
 
-### Deprecated
+- Pinned `AssemblyVersion` to `1.0.0.0` so consumers no longer need to recompile
+  or add binding redirects on patch/minor updates. `FileVersion` and
+  `InformationalVersion` continue to track the package `Version`.
+- Internal: adopted the canonical analyzer set and `TreatWarningsAsErrors` Release
+  gate via `Directory.Build.props`; added public-API surface tracking
+  (`Microsoft.CodeAnalysis.PublicApiAnalyzers`) as a breaking-change gate.
+- Internal: standardized the README to the canonical structure with status badges.
 
-### Removed
+### Added
 
-### Fixed
+- BenchmarkDotNet baseline project and a curated `benchmarks/.editorconfig`.
+- Stryker.NET mutation-testing configuration.
+- DocFX documentation version picker wired into the docs site.
 
-### Security
+## [0.1.0] - 2026-04-27
+
+Initial release.
+
+### Added
+
+- Substring helpers: `Left` and `Right` (length-clamping, null-tolerant).
+- `PadCenter(totalWidth)` and `PadCenter(totalWidth, paddingChar)` — center a
+  string within a width, padding both sides.
+- Case conversions: `ToCamelCase`, `ToKebabCase`, `ToPascalCase`, `ToSnakeCase`,
+  and `ToTitleCase`.
+- Multi-targeting: .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, .NET 10.0.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/String-Extensions/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Chris-Wolfgang/String-Extensions/releases/tag/v0.1.0


### PR DESCRIPTION
The CHANGELOG was an empty skeleton. This adds:
- **`[0.1.0] - 2026-04-27`** — the initial public API (Left/Right, PadCenter, the five `ToXxxCase` methods, multi-TFM).
- **`[Unreleased]`** — the v0.1.1 canonical maintenance round (AssemblyVersion pinned to 1.0.0.0 for binding stability; analyzer/PublicApiAnalyzers/benchmarks/Stryker/version-picker/README tooling). No public API change vs v0.1.0.

Matches the sibling-repo CHANGELOG convention (dated release sections + prose intro; `Internal:` bullets under Changed). The release process stamps `[Unreleased]` → `[0.1.1] - <date>` at ship time.

Refs #72, #69