### PR TITLE
Fix stale workflow file links in solution (#55)

### DIFF
--- a/String Extensions.slnx
+++ b/String Extensions.slnx
@@ -19,10 +19,12 @@
     <File Path=".github/ISSUE_TEMPLATE/feature_request.md" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
-    <File Path=".github/workflows/create-labels.yaml" />
+    <File Path=".github/workflows/build-all-versions.yaml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
+    <File Path=".github/workflows/stryker.yaml" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/Wolfgang.Extensions.String.Benchmarks/Wolfgang.Extensions.String.Benchmarks.csproj" />


### PR DESCRIPTION
The `.slnx` solution file referenced a non-existent `create-labels.yaml` and omitted `codeql.yaml`, `stryker.yaml`, and `build-all-versions.yaml`. Synced the solution-folder workflow list to the actual `.github/workflows/` contents (cosmetic — IDE solution-explorer links only).

Refs #55