### PR TITLE
Rename Left/Right tests to snake_case _when_ convention (#89)

### DIFF
--- a/tests/Wolfgang.Extensions.String.Tests.Unit/LeftTests.cs
+++ b/tests/Wolfgang.Extensions.String.Tests.Unit/LeftTests.cs
@@ -3,7 +3,7 @@ namespace Wolfgang.Extensions.String.Tests.Unit;
 public class LeftTests
 {
     [Fact]
-    public void Left_WhenPassedLengthLessThanZero_ThrowsArgumentOutOfRangeException()
+    public void Left_when_passed_length_less_than_zero_throws_ArgumentOutOfRangeException()
     {
         var sut = "Sample Text";
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Left(-1));
@@ -13,7 +13,7 @@ public class LeftTests
 
 
     [Fact]
-    public void Left_WhenPassedNull_ReturnsNull()
+    public void Left_when_passed_null_returns_null()
     {
         var sut = (string?)null;
 
@@ -23,7 +23,7 @@ public class LeftTests
 
 
     [Fact]
-    public void Left_WhenPassedEmptyString_ReturnsEmptyString()
+    public void Left_when_passed_empty_string_returns_empty_string()
     {
         var sut = string.Empty;
 
@@ -33,7 +33,7 @@ public class LeftTests
         
 
     [Fact]
-    public void Left_WhenPassedStringShorterThanSpecifiedLength_ReturnEntireString()
+    public void Left_when_passed_string_shorter_than_specified_length_returns_entire_string()
     {
         var sut = "1234";
 
@@ -43,7 +43,7 @@ public class LeftTests
 
 
     [Fact]
-    public void Left_WhenPassedStringIsEqualToLengthSpecified_ReturnEntireString()
+    public void Left_when_passed_string_is_equal_to_length_specified_returns_entire_string()
     {
         var sut = "12345";
 
@@ -56,7 +56,7 @@ public class LeftTests
     [InlineData("123456", 5, "12345")]
     [InlineData("bobcat", 3, "bob")]
     [InlineData("Sample Text", 4, "Samp")]
-    public void Left_WhenPassedStringIsGreaterThanLengthSpecified_ReturnOnlyTheSpecifiedPortion(string sut, int length, string expectedResult)
+    public void Left_when_passed_string_is_greater_than_length_specified_returns_only_the_specified_portion(string sut, int length, string expectedResult)
     {
         Assert.Equal(expectedResult, sut.Left(length));
     }

--- a/tests/Wolfgang.Extensions.String.Tests.Unit/RightTests.cs
+++ b/tests/Wolfgang.Extensions.String.Tests.Unit/RightTests.cs
@@ -4,7 +4,7 @@ public class RightTests
 {
 
     [Fact]
-    public void Right_WhenPassedLengthLessThanZero_ThrowsArgumentOutOfRangeException()
+    public void Right_when_passed_length_less_than_zero_throws_ArgumentOutOfRangeException()
     {
         var sut = "Sample Text";
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => sut.Right(-1));
@@ -14,7 +14,7 @@ public class RightTests
 
 
     [Fact]
-    public void Right_WhenPassedNull_ReturnsNull()
+    public void Right_when_passed_null_returns_null()
     {
         string? sut = null;
 
@@ -24,7 +24,7 @@ public class RightTests
 
 
     [Fact]
-    public void Right_WhenPassedEmptyString_ReturnsEmptyString()
+    public void Right_when_passed_empty_string_returns_empty_string()
     {
         var sut = string.Empty;
 
@@ -34,7 +34,7 @@ public class RightTests
 
 
     [Fact]
-    public void Right_WhenPassedStringShorterThanSpecifiedLength_ReturnEntireString()
+    public void Right_when_passed_string_shorter_than_specified_length_returns_entire_string()
     {
         var sut = "1234";
 
@@ -44,7 +44,7 @@ public class RightTests
 
 
     [Fact]
-    public void Right_WhenPassedStringIsEqualToLengthSpecified_ReturnEntireString()
+    public void Right_when_passed_string_is_equal_to_length_specified_returns_entire_string()
     {
         var sut = "12345";
 
@@ -57,7 +57,7 @@ public class RightTests
     [InlineData("123456", 5, "23456")]
     [InlineData("bobcat", 3, "cat")]
     [InlineData("Sample Text", 4, "Text")]
-    public void Right_WhenPassedStringIsGreaterThanLengthSpecified_ReturnOnlyTheSpecifiedPortion(string value, int length, string expectedResult)
+    public void Right_when_passed_string_is_greater_than_length_specified_returns_only_the_specified_portion(string value, int length, string expectedResult)
     {
         var sut = value;
 


### PR DESCRIPTION
The 12 `Left`/`Right` tests used PascalCase (`Left_WhenPassedNull_ReturnsNull`); the CLAUDE.md standard is `Method_when_condition_expected_result`. The other 50 tests (PadCenter, ToXxxCase) already conformed, so this renames only the 12 divergent ones (type names like `ArgumentOutOfRangeException` kept as-is).

Pure rename — no behavior change. **95 tests pass** locally (Release, net8.0).

Refs #89