### PR TITLE
Code-review fixes: PackageTags, ToCamelCase tidy, examples cleanup (#61)

### DIFF
--- a/examples/Wolfgang.Extensions.String.Examples/Program.cs
+++ b/examples/Wolfgang.Extensions.String.Examples/Program.cs
@@ -11,16 +11,16 @@ internal abstract class Program
 
 
 
-        private static void PadCenter()
-        {
-            Console.WriteLine("\tPadCenter\n\n");
+    private static void PadCenter()
+    {
+        Console.WriteLine("\tPadCenter\n\n");
 
-            Console.WriteLine($"\t{"Name".PadCenter(10)}|{"Date".PadCenter(12)}");
-            Console.WriteLine("\t----------+------------");
-            Console.WriteLine($"\t{"Steve",-10}|{DateTime.Today.ToString("MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture).PadCenter(12)}");
-            Console.WriteLine($"\t{"Jane",-10}|{new DateTime(2012, 1, 2, 0, 0, 0, DateTimeKind.Unspecified).ToString("M/d/yyyy", System.Globalization.CultureInfo.InvariantCulture).PadCenter(12)}");
-            Console.WriteLine();
-        }
+        Console.WriteLine($"\t{"Name".PadCenter(10)}|{"Date".PadCenter(12)}");
+        Console.WriteLine("\t----------+------------");
+        Console.WriteLine($"\t{"Steve",-10}|{DateTime.Today.ToString("MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture).PadCenter(12)}");
+        Console.WriteLine($"\t{"Jane",-10}|{new DateTime(2012, 1, 2, 0, 0, 0, DateTimeKind.Unspecified).ToString("M/d/yyyy", System.Globalization.CultureInfo.InvariantCulture).PadCenter(12)}");
+        Console.WriteLine();
+    }
 
 
     private static void Left()
@@ -78,8 +78,9 @@ internal abstract class Program
         Console.WriteLine($"\tToPascalCase: \"{testString.ToPascalCase()}\".\n");
         Console.WriteLine($"\tToSnakeCase: \"{testString.ToSnakeCase()}\".\n");
         Console.WriteLine($"\tToTitleCase: \"{testString.ToTitleCase()}\".\n");
-        
+
         Console.WriteLine("\n");
+        Console.ResetColor();
     }
 
 }

--- a/src/Wolfgang.Extensions.String/StringExtensions.cs
+++ b/src/Wolfgang.Extensions.String/StringExtensions.cs
@@ -191,7 +191,6 @@ public static class StringExtensions
             else if (isLastCharSeparator && foundFirstChar)
             {
                 isLastCharSeparator = false;
-                foundFirstChar = true;
                 output[outputIndex++] = char.ToUpperInvariant(chr);
             }
             else

--- a/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
+++ b/src/Wolfgang.Extensions.String/Wolfgang.Extensions.String.csproj
@@ -18,6 +18,7 @@
 		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for strings</Description>
+			<PackageTags>string;strings;extensions;extension-methods;left;right;padcenter;camelcase;kebabcase;pascalcase;snakecase;titlecase;dotnet;netstandard</PackageTags>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/String-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/String-Extensions.git</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Findings from the full code-review pass (#61):

1. **[should-fix]** `src/…csproj` — added missing `<PackageTags>` (NuGet discoverability; matches the sibling-repo canonical, e.g. ICollection-Extensions).
2. **[nit]** `StringExtensions.ToCamelCase` — removed a redundant `foundFirstChar = true;` in the `else if` branch (already true). No behavior change.
3. **[nit]** `examples/…/Program.cs` — fixed `PadCenter()` over-indentation (8→4), added `Console.ResetColor()` to `ToXxxCase()` (was leaving the console foreground white), removed a trailing-whitespace line.

The repo was otherwise clean across all review phases (best practices, public API, perf, dead code, test quality, XML docs, docs files). **95 tests pass**; src + examples build clean in Release.

Refs #61